### PR TITLE
Fixed network alert not to appear when running on macOS.

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -53,7 +53,7 @@ export const initialize = async (app: App, port: number = 0) => {
     throw new Error("The electron application is already listening on a port. Double `initialize`?");
   }
 
-  const actualPort = port === 0 ? await getPort() : port;
+  const actualPort = port === 0 ? await getPort({host: '127.0.0.1'}) : port;
   app.commandLine.appendSwitch(
     "remote-debugging-port",
     `${actualPort}`

--- a/index.ts
+++ b/index.ts
@@ -53,7 +53,7 @@ export const initialize = async (app: App, port: number = 0) => {
     throw new Error("The electron application is already listening on a port. Double `initialize`?");
   }
 
-  const actualPort = port === 0 ? await getPort({host: '127.0.0.1'}) : port;
+  const actualPort = port === 0 ? await getPort({host: "127.0.0.1"}) : port;
   app.commandLine.appendSwitch(
     "remote-debugging-port",
     `${actualPort}`


### PR DESCRIPTION
Hi:exclamation: Thanks for the nice library:exclamation::smile:

I found a problem with the behavior of this library on macOS, and created a PR for it.

If you run the following code on macOS, you will get an alert like this.

```javascript
const {BrowserWindow, app} = require("electron");
const pie = require("puppeteer-in-electron")
const puppeteer = require("puppeteer-core");

const main = async () => {
  await pie.initialize(app);
  const browser = await pie.connect(app, puppeteer);

  const window = new BrowserWindow();
  const url = "https://example.com/";
  await window.loadURL(url);

  const page = await pie.getPage(browser, window);
  // console.log(page.url());
  // window.destroy();
};

main();
```

<img width="532" alt="スクリーンショット 2021-04-26 22 58 34" src="https://user-images.githubusercontent.com/12657833/116099157-a4a68f00-a6e6-11eb-8876-06fa932bc5d5.png">

<details>

<summary>Translation of alert text</summary>

```console
Do you want to allow incoming network connections to the application "Electron.app"?

If you click "Deny", some features of the application may become unavailable. This setting can be changed in the "Firewall" panel of the "Security and Privacy" preferences.

[deny] [allow]
```

</details>

This alert occurs because `getPort` also tries to get the port for the outgoing address.
Specifying the host as 127.0.0.1 will prevent it.

Internally, this is equivalent to the following changes.

```console
#### Alert appears. 

$ cat index.js
require('net').createServer().listen({port:0});
$ electron . 

##### Alert doesn't appear.

$ cat index.js
require('net').createServer().listen({port:0, host: "127.0.0.1"});
$ electron . 

```